### PR TITLE
fix: enable scrolling on dashboard pages

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -5,7 +5,7 @@ export function Layout() {
   return (
     <div className="flex h-screen overflow-hidden">
       <Sidebar />
-      <main className="flex-1 flex flex-col overflow-hidden p-6">
+      <main className="flex-1 flex flex-col overflow-auto p-6">
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
Changed overflow-hidden to overflow-auto on the main layout container to allow dashboard pages to scroll. Table pages continue to work as they manage their own internal scrolling.

Fixes #11

---

Generated with [Claude Code](https://claude.ai/code)