### PR TITLE
fix: Hide dashboard edit functionality from non-authenticated users

### DIFF
--- a/frontend/src/pages/dashboards/index.tsx
+++ b/frontend/src/pages/dashboards/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/contexts/auth-context";
 import {
   Table,
   TableBody,
@@ -36,6 +37,7 @@ const emptyFormData: FormData = {
 
 export default function DashboardsPage() {
   const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -106,13 +108,14 @@ export default function DashboardsPage() {
             Create and manage custom dashboards with charts and tables
           </p>
         </div>
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-          <DialogTrigger asChild>
-            <Button onClick={openAddDialog}>
-              <Plus className="mr-2 h-4 w-4" />
-              New Dashboard
-            </Button>
-          </DialogTrigger>
+        {isAuthenticated && (
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger asChild>
+              <Button onClick={openAddDialog}>
+                <Plus className="mr-2 h-4 w-4" />
+                New Dashboard
+              </Button>
+            </DialogTrigger>
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Create Dashboard</DialogTitle>
@@ -154,7 +157,8 @@ export default function DashboardsPage() {
               </div>
             </form>
           </DialogContent>
-        </Dialog>
+          </Dialog>
+        )}
       </div>
 
       <div className="rounded-md border">
@@ -165,7 +169,7 @@ export default function DashboardsPage() {
               <TableHead>Name</TableHead>
               <TableHead>Description</TableHead>
               <TableHead>Last Updated</TableHead>
-              <TableHead className="w-[60px]"></TableHead>
+              {isAuthenticated && <TableHead className="w-[60px]"></TableHead>}
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -185,19 +189,21 @@ export default function DashboardsPage() {
                 <TableCell className="font-mono text-sm">
                   {formatDateTime(dashboard.updated_at)}
                 </TableCell>
-                <TableCell>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDelete(dashboard.id);
-                    }}
-                    title="Delete dashboard"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </TableCell>
+                {isAuthenticated && (
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(dashboard.id);
+                      }}
+                      title="Delete dashboard"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                )}
               </TableRow>
             ))}
             {dashboards.length === 0 && (

--- a/frontend/src/pages/dashboards/view.tsx
+++ b/frontend/src/pages/dashboards/view.tsx
@@ -3,11 +3,13 @@ import { useParams, Link } from "react-router";
 import { Button } from "@/components/ui/button";
 import { DashboardGrid } from "@/components/dashboard";
 import { Pencil, ArrowLeft } from "lucide-react";
+import { useAuth } from "@/contexts/auth-context";
 import type { Dashboard, DashboardComponent } from "@/lib/db/types";
 
 export default function DashboardViewPage() {
   const params = useParams();
   const dashboardId = parseInt(params.id as string, 10);
+  const { isAuthenticated } = useAuth();
 
   const [dashboard, setDashboard] = useState<Dashboard | null>(null);
   const [components, setComponents] = useState<DashboardComponent[]>([]);
@@ -76,12 +78,14 @@ export default function DashboardViewPage() {
             )}
           </div>
         </div>
-        <Button asChild>
-          <Link to={`/dashboards/${dashboardId}/edit`}>
-            <Pencil className="mr-2 h-4 w-4" />
-            Edit Dashboard
-          </Link>
-        </Button>
+        {isAuthenticated && (
+          <Button asChild>
+            <Link to={`/dashboards/${dashboardId}/edit`}>
+              <Pencil className="mr-2 h-4 w-4" />
+              Edit Dashboard
+            </Link>
+          </Button>
+        )}
       </div>
 
       <DashboardGrid components={components} editable={false} />

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, Navigate } from "react-router";
 import { Layout } from "@/components/layout/Layout";
+import { RequireAuth } from "@/components/auth/require-auth";
 
 // Lazy load pages
 import { lazy, Suspense } from "react";
@@ -67,7 +68,7 @@ export const router = createBrowserRouter([
       { path: "manage/sync", element: withSuspense(ManageSyncSettingsPage) },
       { path: "dashboards", element: withSuspense(DashboardsListPage) },
       { path: "dashboards/:id", element: withSuspense(DashboardViewPage) },
-      { path: "dashboards/:id/edit", element: withSuspense(DashboardEditPage) },
+      { path: "dashboards/:id/edit", element: <RequireAuth>{withSuspense(DashboardEditPage)}</RequireAuth> },
     ],
   },
 ]);


### PR DESCRIPTION
Fixes #25

### Changes
- Hide Edit Dashboard button on view page for non-authenticated users
- Protect dashboard edit route with RequireAuth wrapper
- Hide New Dashboard and Delete buttons on list page for non-authenticated users
- Maintain existing API-level authentication while improving UX

Generated with [Claude Code](https://claude.ai/code)