### PR TITLE
URGENT: Fix Dockerfile - copy migration startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,10 +67,12 @@ RUN python3 -m venv /app/backend/.venv \
 COPY deploy/nginx-container.conf /etc/nginx/sites-available/default
 COPY deploy/supervisord.conf /etc/supervisor/conf.d/opengov.conf
 COPY deploy/sync-cron /etc/cron.d/opengov-sync
+COPY deploy/run-migrations-then-api.sh /app/deploy/run-migrations-then-api.sh
 
-# Setup cron
+# Setup cron and make migration script executable
 RUN chmod 0644 /etc/cron.d/opengov-sync \
-    && crontab /etc/cron.d/opengov-sync
+    && crontab /etc/cron.d/opengov-sync \
+    && chmod +x /app/deploy/run-migrations-then-api.sh
 
 # Create data directory
 RUN mkdir -p /data


### PR DESCRIPTION
## Problem

**Production site is down with 502 errors** - API container fails to start with exit code 127.

### Root Cause

The `Dockerfile` is missing the `COPY` instruction for `deploy/run-migrations-then-api.sh`. The supervisord config tries to execute this script, but it doesn't exist in the container, causing:

```
/bin/bash: /app/deploy/run-migrations-then-api.sh: No such file or directory
```

### Impact

- ✅ Frontend: Working fine
- ❌ API: Fatal - all requests return 502 Bad Gateway
- ❌ Health check: Failing (container marked unhealthy)

## Solution

Add missing lines to Dockerfile:

```dockerfile
COPY deploy/run-migrations-then-api.sh /app/deploy/run-migrations-then-api.sh

# Make script executable
RUN chmod +x /app/deploy/run-migrations-then-api.sh
```

## Evidence from Production

Supervisor logs show API exiting immediately:
```
2026-01-14 09:20:03,730 WARN exited: api (exit status 127; not expected)
2026-01-14 09:20:09,780 INFO gave up: api entered FATAL state, too many start retries too quickly
```

API error log shows the missing script:
```
/bin/bash: /app/deploy/run-migrations-then-api.sh: No such file or directory
```

## Testing

- ✅ Verified script exists locally in `deploy/` directory
- ✅ Confirmed Dockerfile was missing COPY instruction
- ✅ Added COPY and chmod commands

## Deployment

This needs to be merged and deployed immediately to restore production service.

After merge, deploy to production:
```bash
git checkout production
git merge main
git push origin production
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)