### PR TITLE
docs: Add deployment best practices from production incident

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,13 +77,22 @@ pnpm migrate:baseline --version N  # Mark migrations up to N as applied (for exi
 | Backend business rules | [backend/docs/spec/business-rules.md](backend/docs/spec/business-rules.md) |
 | API validation | [api/docs/spec/validation.md](api/docs/spec/validation.md) |
 | Database migrations | [docs/spec/migrations.md](docs/spec/migrations.md), [backend/migrations/README.md](backend/migrations/README.md) |
+| Deployment & Docker | [deploy/CLAUDE.md](deploy/CLAUDE.md) |
 
 ## Tool Usage
 - Bash: Don't chain commands with `&&`. Run them sequentially instead.
 
 ## Before Committing
 Always run these commands and ensure they pass before committing:
-- Build: `pnpm run build`  
+- Build: `pnpm run build`
 - Test: `pnpm test`
 
 If either fails, fix the issues before committing.
+
+## Before Deploying
+If your changes affect Docker, supervisord, or startup scripts:
+- Test: `docker compose up --build`
+- Verify: `curl http://localhost/api/health`
+- Check: `docker compose exec opengov-monitor supervisorctl status`
+
+See [deploy/CLAUDE.md](deploy/CLAUDE.md) for full pre-deployment checklist.

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -55,11 +55,85 @@ OS Login enabled for faster deploys (no SSH key generation):
 - Instance metadata: `enable-oslogin=TRUE`
 - Service account: `roles/compute.osAdminLogin`
 
+## Pre-Deployment Checklist
+
+**ALWAYS verify these before deploying to production:**
+
+1. **Test Docker build locally**
+   ```bash
+   docker compose up --build
+   ```
+
+2. **Verify all files referenced in supervisord.conf exist**
+   ```bash
+   # Check supervisord config
+   grep "command=" deploy/supervisord.conf
+
+   # Verify each file/script exists and is copied in Dockerfile
+   # Example: if supervisord.conf has "command=/app/deploy/script.sh"
+   # Then Dockerfile MUST have "COPY deploy/script.sh /app/deploy/script.sh"
+   ```
+
+3. **Test container health locally**
+   ```bash
+   # Wait 10 seconds for startup
+   sleep 10
+
+   # Health check should return 200
+   curl -f http://localhost/api/health
+
+   # Check supervisor status
+   docker compose exec opengov-monitor supervisorctl status
+   ```
+
+4. **Verify all processes are running**
+   - ✅ nginx: RUNNING
+   - ✅ api: RUNNING (not FATAL)
+   - ✅ cron: RUNNING
+
+5. **Run tests**
+   ```bash
+   pnpm test
+   pnpm run build
+   ```
+
 ## Deployment Flow
 
-1. Push to `production` branch
-2. GitHub Actions builds image → `ghcr.io`
-3. `deploy-service` pulls and restarts on server
+1. **Complete pre-deployment checklist** (see above)
+2. Push to `production` branch
+3. GitHub Actions builds image → `ghcr.io`
+4. `deploy-service` pulls and restarts on server
+5. **Verify deployment** (see Post-Deployment Verification below)
+
+## Post-Deployment Verification
+
+**Run these immediately after deployment:**
+
+```bash
+# 1. Check container status (should be "healthy")
+gcloud compute ssh web-server --zone=us-central1-a --tunnel-through-iap \
+  --command="sudo /usr/local/bin/service-status opengov-monitor"
+
+# 2. Verify all supervisor processes running
+gcloud compute ssh web-server --zone=us-central1-a --tunnel-through-iap \
+  --command="sudo docker exec opengov-monitor supervisorctl status"
+
+# Expected output:
+# api     RUNNING   pid X, uptime X:XX:XX
+# cron    RUNNING   pid X, uptime X:XX:XX
+# nginx   RUNNING   pid X, uptime X:XX:XX
+
+# 3. Test health endpoint
+curl -f https://polkadot-treasury-monitor.cypherpunk.agency/api/health
+
+# 4. Test a data endpoint
+curl -f https://polkadot-treasury-monitor.cypherpunk.agency/api/categories
+```
+
+**If any check fails, investigate immediately:**
+- Container unhealthy → Check supervisor logs
+- API not RUNNING → Check api-error.log
+- Health endpoint fails → Check nginx and API logs
 
 ## Debugging
 
@@ -92,3 +166,93 @@ docker compose exec opengov-monitor /app/backend/.venv/bin/python /app/backend/s
 ```
 
 Health check: `curl http://localhost/api/health`
+
+## Common Pitfalls
+
+### 1. Missing Files in Container (Exit Code 127)
+
+**Symptom:** Supervisor logs show `exit status 127` or error log shows `No such file or directory`
+
+**Cause:** supervisord.conf references a script/file that wasn't copied to the container
+
+**Fix:**
+1. Check what files supervisord.conf references:
+   ```bash
+   grep "command=" deploy/supervisord.conf
+   ```
+2. Ensure Dockerfile has `COPY` for each file
+3. For scripts, ensure they're executable:
+   ```dockerfile
+   COPY deploy/script.sh /app/deploy/script.sh
+   RUN chmod +x /app/deploy/script.sh
+   ```
+
+**Example (2026-01-14):** Missing `deploy/run-migrations-then-api.sh` caused all API requests to return 502
+
+**Prevention:** Always test Docker build locally before deploying
+
+### 2. API Not Starting Due to Migration Failure
+
+**Symptom:** API shows FATAL in supervisor status, migrations-error.log shows errors
+
+**Cause:** Database migration failed, blocking API startup
+
+**Debug:**
+```bash
+# Check migration error log
+gcloud compute ssh web-server --zone=us-central1-a --tunnel-through-iap \
+  --command="sudo docker exec opengov-monitor cat /var/log/supervisor/migrations-error.log"
+
+# Check if database is accessible
+gcloud compute ssh web-server --zone=us-central1-a --tunnel-through-iap \
+  --command="sudo docker exec opengov-monitor ls -la /data/"
+```
+
+**Fix:** Fix the migration issue, then restart container
+
+### 3. Container Builds But Health Check Fails
+
+**Symptom:** Container status shows "unhealthy", but no obvious errors
+
+**Cause:** Health check expects `/api/health` to return 200, but API isn't listening
+
+**Debug:**
+```bash
+# Test health endpoint inside container
+gcloud compute ssh web-server --zone=us-central1-a --tunnel-through-iap \
+  --command="sudo docker exec opengov-monitor curl -f http://localhost/api/health"
+
+# Check if API is listening on port 3001
+gcloud compute ssh web-server --zone=us-central1-a --tunnel-through-iap \
+  --command="sudo docker exec opengov-monitor netstat -tlnp | grep 3001"
+```
+
+### 4. Forgot to Test Locally with Docker
+
+**Issue:** Changes work with `pnpm run dev` locally but fail in production
+
+**Why:** Local dev doesn't use Docker, supervisord, or nginx - different environment
+
+**Solution:** ALWAYS test with Docker before deploying:
+```bash
+# Stop local dev server first
+pnpm run dev  # ❌ Not representative of production
+
+# Test with Docker instead
+docker compose up --build  # ✅ Matches production environment
+curl http://localhost/api/health
+```
+
+### 5. Deployment Checklist Not Followed
+
+**Issue:** Skipping pre-deployment checks leads to broken deployments
+
+**Prevention:** Use this checklist EVERY time:
+- [ ] Test Docker build locally
+- [ ] Verify supervisord.conf references
+- [ ] Check container health locally
+- [ ] Run tests (`pnpm test`)
+- [ ] After deploy: verify health endpoint
+- [ ] After deploy: check supervisor status
+
+**Golden Rule:** If you wouldn't deploy it locally, don't deploy it to production


### PR DESCRIPTION
## Summary

Adds comprehensive documentation based on learnings from the 2026-01-14 production incident where a missing script in the Dockerfile caused a complete API outage.

## What Happened

**Incident:** Production site returned 502 errors for ~50 minutes
**Root Cause:** Dockerfile missing `COPY deploy/run-migrations-then-api.sh`
**Impact:** API container failed to start (exit code 127)

## Documentation Added

### 1. Pre-Deployment Checklist (deploy/CLAUDE.md)

**What to verify BEFORE deploying:**
- Test Docker build locally
- Verify supervisord.conf file references exist in Dockerfile
- Test container health locally
- Verify all processes running
- Run tests

### 2. Post-Deployment Verification (deploy/CLAUDE.md)

**Smoke tests to run AFTER deployment:**
- Check container status (should be "healthy")
- Verify supervisor processes (all should be RUNNING)
- Test health endpoint
- Test data endpoints

### 3. Common Pitfalls (deploy/CLAUDE.md)

**5 documented issues with symptoms, causes, and fixes:**
1. Missing files in container (exit code 127) - **Today's issue**
2. API not starting due to migration failure
3. Container builds but health check fails
4. Forgot to test locally with Docker
5. Deployment checklist not followed

### 4. Before Deploying Section (root CLAUDE.md)

Added quick reference for Docker-related changes with link to full checklist.

## Key Learnings

1. **`pnpm run dev` ≠ Production**
   - Local dev doesn't use Docker, supervisord, or nginx
   - Always test with `docker compose up --build`

2. **Supervisord.conf references must match Dockerfile COPY**
   - If supervisord runs `/app/deploy/script.sh`
   - Then Dockerfile MUST have `COPY deploy/script.sh /app/deploy/script.sh`

3. **Post-deployment verification is critical**
   - Health checks take time to fail
   - Manual verification catches issues immediately

4. **Checklists prevent incidents**
   - Following a systematic checklist would have caught this issue

## Golden Rule Added

> If you wouldn't deploy it locally, don't deploy it to production

## Files Changed

- `deploy/CLAUDE.md` - Added 3 major sections (~170 lines)
- `CLAUDE.md` - Added "Before Deploying" section with link to full checklist

## Future Prevention

This documentation should prevent similar incidents by:
- Making Docker testing a standard practice
- Providing clear checklists for pre/post deployment
- Documenting common issues for faster debugging
- Establishing systematic verification procedures

🤖 Generated with [Claude Code](https://claude.com/claude-code)