### PR TITLE
URGENT: Fix migration script python path

### DIFF
--- a/deploy/run-migrations-then-api.sh
+++ b/deploy/run-migrations-then-api.sh
@@ -7,7 +7,7 @@ set -e  # Exit immediately on error
 
 echo "=== Running database migrations ==="
 cd /app/backend
-python migrations/migration_runner.py --db /data/polkadot.db
+.venv/bin/python migrations/migration_runner.py --db /data/polkadot.db
 
 if [ $? -eq 0 ]; then
     echo "=== Migrations completed successfully ==="


### PR DESCRIPTION
## Problem

**Production still down** - Second issue discovered after fixing Dockerfile.

API container fails with:
```
/app/deploy/run-migrations-then-api.sh: line 10: python: command not found
```

### Root Cause

The migration startup script uses `python` command which doesn't exist in PATH.
Need to use virtualenv python: `.venv/bin/python`

### Fix

```bash
# Before (fails)
python migrations/migration_runner.py

# After (works)
.venv/bin/python migrations/migration_runner.py
```

## Timeline

1. **10:13** - PR #41 merged (fixed missing Dockerfile COPY)
2. **10:17** - Container deployed but API still failing
3. **10:18** - Discovered `python: command not found` error
4. **Now** - Fixing python path in script

## Impact

- Container deployed successfully
- Script file exists and is executable
- But script fails because `python` not in PATH
- API cannot start, 502 errors continue

## Testing

Will verify after merge:
- Container health becomes "healthy"
- API process shows RUNNING in supervisorctl
- Health endpoint returns 200
- Live site works

🤖 Generated with [Claude Code](https://claude.com/claude-code)