### PR TITLE
fix: clip long text in dashboard table columns with tooltip

### DIFF
--- a/src/frontend/src/components/data-table/data-table.tsx
+++ b/src/frontend/src/components/data-table/data-table.tsx
@@ -345,6 +345,7 @@ export function DataTable<TData>({
       facetedFilters,
       columnOverrides,
       columnMapping,
+      dashboardMode,
     });
   }, [
     dataSchema, // Changed from 'data' to 'dataSchema' to prevent regeneration on value changes
@@ -355,6 +356,7 @@ export function DataTable<TData>({
     columnOverrides,
     columnMapping,
     configLoaded,
+    dashboardMode,
   ]);
 
   // VIEW MODE STATE


### PR DESCRIPTION
Fixes #59

## Summary
Fixed the issue where table columns in dashboard components would break or expand beyond their header width when containing long text. Cells now properly clip overflowing text with an ellipsis and show the full content in a tooltip on hover.

## Changes
- Modified auto-columns.tsx to wrap cell content with overflow handling in dashboard mode
- Added title attributes for native browser tooltips
- Cells use overflow-hidden, text-ellipsis, and whitespace-nowrap to clip text cleanly

The fix applies only to dashboard tables to avoid affecting the main data tables.

## Testing
- Build: ✅ Passed
- Frontend tests: ✅ Passed

🤖 Generated with [Claude Code](https://claude.ai/code)