### PR TITLE
feat: Unify Dashboard and DataTable filter UI with FilterGroupBuilder

### DIFF
--- a/docs/spec/frontend/tables.md
+++ b/docs/spec/frontend/tables.md
@@ -367,12 +367,19 @@ type DashboardComponentType =
   sourceTable: string;
   columns: ColumnSelection[];
   expressionColumns?: ExpressionColumn[];  // Computed columns
-  filters: FilterCondition[];              // WHERE clauses
+  filters: FilterCondition[];              // WHERE clauses (flat array storage)
   groupBy?: string[];
   orderBy?: OrderByConfig[];
   limit?: number;
 }
 ```
+
+**Note on Filters:**
+- Dashboard components store filters as flat `FilterCondition[]` array for backward compatibility
+- UI uses `FilterGroupBuilder` component for editing (converted to/from `FilterGroup` format at UI boundary)
+- All operators supported including IN operator (comma-separated values)
+- Nested filter groups are automatically flattened to AND on save (with console warning)
+- Future enhancement (Phase 2): Full nested `FilterGroup` storage for complex AND/OR logic
 
 #### GridConfig - Grid layout
 ```tsx
@@ -398,7 +405,7 @@ type DashboardComponentType =
   2. JOIN tables (auto-populated ON conditions)
   3. Column picker with alias support (includes joined table columns, grouped by table)
   4. Expression columns (computed: `column1 + column2`)
-  5. Filter UI for WHERE conditions
+  5. Filter UI using FilterGroupBuilder component (10 operators including IN)
   6. ORDER BY controls
 - **JOIN support** (LEFT, INNER, RIGHT)
   - Auto-detects FK relationships (e.g., `category_id`, `parentBountyId`)


### PR DESCRIPTION
## Summary

Replaces QueryBuilder's basic inline filter UI with the advanced `FilterGroupBuilder` component already used in DataTable. This provides consistent filter UX across both systems while maintaining full backward compatibility.

## Changes

### 1. QueryBuilder Filter UI Replacement
- **Before:** Basic inline filters with 9 operators, no IN support
- **After:** FilterGroupBuilder with 10 operators including IN operator
- Removed old filter functions: `addFilter()`, `updateFilter()`, `removeFilter()`
- Integrated FilterGroupBuilder with conversion at UI boundary

### 2. Conversion Utilities
Added to `src/frontend/src/lib/query-config-utils.ts`:
- `filtersToGroup()` - converts flat FilterCondition[] to FilterGroup for UI
- `groupToFilters()` - converts FilterGroup back to flat array for storage
- Handles nested groups by flattening with console warning

### 3. Comprehensive Test Coverage
Added 14 new unit tests in `query-config-utils.test.ts`:
- Filter to group conversions (4 tests)
- Group to filter conversions (7 tests)
- Round-trip data preservation (3 tests)
- Total: 237 frontend tests (was 223)

### 4. Documentation Updates
Updated `docs/spec/frontend/tables.md`:
- Documented filter storage format and conversion behavior
- Noted IN operator support
- Explained nested group flattening

## Benefits

✅ **UI Consistency:** Same filter interface across DataTable and Dashboard  
✅ **Feature Parity:** IN operator now available in dashboards  
✅ **Better UX:** Improved operator labels ("equals", "contains", "in list", etc.)  
✅ **Maintainability:** Single filter component to maintain  
✅ **Performance:** FilterGroupBuilder already optimized (React.memo, useCallback)  
✅ **Future-Ready:** Easy path to Phase 2 (nested FilterGroup storage) if needed  

## Backward Compatibility

- ✅ Dashboard storage remains flat `FilterCondition[]` array (no DB changes)
- ✅ No migration required - existing dashboards work unchanged
- ✅ Backend already supports both FilterCondition[] and FilterGroup formats
- ✅ Nested groups (edge case) flatten gracefully with warning

## Testing

### Build & Tests
```
✅ Build: Passed
✅ API Tests: 361 passed
✅ Frontend Tests: 237 passed (+14 new tests)
```

### Manual Testing Needed
1. Create new dashboard with filters using the new UI
2. Test IN operator with comma-separated values (e.g., "Active, Pending")
3. Open existing dashboards and verify filters display correctly
4. Edit filters and verify preview updates correctly

## Implementation Details

**Phase 1 (this PR):** UI unification with flat storage  
**Phase 2 (future):** Full nested FilterGroup storage if users request complex AND/OR logic

## Related

Implements the plan from issue #62 (if exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)