### PR TITLE
feat: Sort Child Bounties by latest status change DESC

### DIFF
--- a/src/frontend/src/pages/child-bounties.tsx
+++ b/src/frontend/src/pages/child-bounties.tsx
@@ -38,7 +38,7 @@ const defaultChildBountiesViews: SavedView[] = [
   {
     name: "All",
     state: {
-      sorting: [{ id: "identifier", desc: true }],
+      sorting: [{ id: "latest_status_change", desc: true }],
       columnFilters: [],
       columnVisibility: {},
       pagination: { pageIndex: 0, pageSize: 100 },
@@ -237,7 +237,7 @@ export default function ChildBountiesPage() {
         isAuthenticated={isAuthenticated}
         facetedFilters={["status"]}
         columnOverrides={columnOverrides}
-        defaultSorting={[{ id: "identifier", desc: true }]}
+        defaultSorting={[{ id: "latest_status_change", desc: true }]}
         defaultViews={defaultChildBountiesViews}
       />
     </div>


### PR DESCRIPTION
Changed the default sorting for the Child Bounties screen from identifier to latest_status_change in descending order. This shows the most recently updated bounties first.

Fixes #83

Generated with [Claude Code](https://claude.ai/code)