### PR TITLE
feat: add download button to dashboard tables

### DIFF
--- a/src/frontend/src/components/data-table/data-table.tsx
+++ b/src/frontend/src/components/data-table/data-table.tsx
@@ -71,6 +71,10 @@ interface DataTableProps<TData> {
   // Controlled toolbar collapse state (for dashboard integration)
   toolbarCollapsed?: boolean;
   onToolbarCollapseChange?: (collapsed: boolean) => void;
+
+  // Export handler callbacks for external download buttons (dashboard integration)
+  onExportCSV?: (handler: () => void) => void;
+  onExportJSON?: (handler: () => void) => void;
 }
 
 export function DataTable<TData>({
@@ -94,6 +98,8 @@ export function DataTable<TData>({
   initialToolbarCollapsed: initialToolbarCollapsedProp,
   toolbarCollapsed,
   onToolbarCollapseChange,
+  onExportCSV,
+  onExportJSON,
 }: DataTableProps<TData>) {
   // Apply defaults based on dashboardMode
   const hideViewSelector = hideViewSelectorProp ?? dashboardMode;
@@ -523,6 +529,8 @@ export function DataTable<TData>({
           id: getColumnKey(col),
           name: col.alias || col.column,
         }))}
+        onExportCSV={onExportCSV}
+        onExportJSON={onExportJSON}
       />
 
       {viewMode === "card" ? (


### PR DESCRIPTION
Closes #99

Adds download button with CSV and JSON export options to dashboard table components. The button appears in the component header next to the toolbar collapse button, providing easy access to data export functionality.

## Changes
- Add download dropdown button to table headers in dashboard-component.tsx
- Expose export handlers from DataTable to parent components
- Wire up export callbacks through the component hierarchy
- Reuse existing export functionality from lib/export.ts

## Testing
- Build: ✓ Passed
- Tests: ✓ All 764 tests passed (385 backend + 379 frontend)

Generated with [Claude Code](https://claude.ai/code)