### PR TITLE
Fix: Ensure consistent colors between pie and bar charts

### DIFF
--- a/src/frontend/src/components/dashboard/dashboard-component.tsx
+++ b/src/frontend/src/components/dashboard/dashboard-component.tsx
@@ -341,8 +341,10 @@ export const DashboardComponent = memo(
               stacked={component.type === "bar_stacked"}
               showLegend={chartConfig.showLegend ?? true}
               showTooltip={chartConfig.showTooltip ?? true}
+              colors={chartConfig.colors}
               tableName={tableName}
               columnMapping={columnMapping}
+              colorByRow={barChartData.colorByRow}
             />
           </Suspense>
         );


### PR DESCRIPTION
### Summary
When a pie chart and bar chart display the same grouped query results, they now use consistent colors based on row order. This allows charts to be placed side-by-side without confusing users.

### Changes
- Add colorByRow prop to bar chart component to enable row-based coloring
- Automatically enable colorByRow for simple bar charts (single value column)
- Use Cell component to assign individual colors to each bar
- Pass colors config from dashboard to bar charts

Fixes #89

Generated with [Claude Code](https://claude.ai/code)