### PR TITLE
Fix table download to export full query result

### DIFF
--- a/src/frontend/src/components/data-table/data-table.tsx
+++ b/src/frontend/src/components/data-table/data-table.tsx
@@ -531,6 +531,7 @@ export function DataTable<TData>({
         }))}
         onExportCSV={onExportCSV}
         onExportJSON={onExportJSON}
+        fullQueryConfig={queryConfig}
       />
 
       {viewMode === "card" ? (


### PR DESCRIPTION
Fixes #77

The table download button now exports the full query result instead of only the 100 visible rows.

### Changes
- Modified DataTableToolbar to fetch full query results by removing limit and offset parameters
- Export handlers now make a separate API call to get all rows
- Added fallback to export visible data if full query fetch fails

Generated with [Claude Code](https://claude.ai/code)